### PR TITLE
Fix deprecated warnings.

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -14,7 +14,6 @@ const options = {
   headers: {
     'user-agent': 'PR-Bot',
   },
-  Promise,
   timeout: 10000,
 };
 

--- a/test/src/pull_request.spec.js
+++ b/test/src/pull_request.spec.js
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import { assert } from 'chai';
 import config from 'config';
 
@@ -17,7 +16,6 @@ describe('PullRequest', () => {
     headers: {
       'user-agent': 'PR-Bot',
     },
-    Promise,
     timeout: 10000,
   };
 


### PR DESCRIPTION
```
DEPRECATED: Promise option is no longer supported. The native Promise API is used
```
https://github.com/octokit/rest.js
